### PR TITLE
quick-submit: update gh check status of results commit

### DIFF
--- a/.github/workflows/quick-submit-runner.yml
+++ b/.github/workflows/quick-submit-runner.yml
@@ -477,6 +477,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      statuses: write
     defaults:
       run:
         shell: bash
@@ -585,6 +586,17 @@ jobs:
           git add "results/${BASE}.json" "submissions/${BASE}-provenance.json"
           git commit -m "[AgentBeats] Scenario results"
           git push
+
+      - name: Set status on results commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RESULTS_SHA=$(git rev-parse HEAD)
+          gh api "repos/${{ github.repository }}/statuses/${RESULTS_SHA}" \
+            -f state=success \
+            -f context="run-scenario" \
+            -f description="Scenario completed successfully" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       # Cleanup: delete secrets from backend.
       # Skipped when no backend is configured.

--- a/.github/workflows/quick-submit.yml
+++ b/.github/workflows/quick-submit.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      statuses: write
     with:
       num_shards: 1
     # Optional: bind leaderboard-repo secrets into the green agent during Quick Submit.


### PR DESCRIPTION
Context:

It'd be nice to require all checks to pass on the submission PRs before allowing the bot to auto-merge. Under the current setup, the quick-submit-runner appends an additional commit to the PR with the results, but this commit doesn't have the requisite status checks. This PR adds that green status. 