### PR TITLE
Allow scenario submission shard num override

### DIFF
--- a/.github/workflows/quick-submit-runner.yml
+++ b/.github/workflows/quick-submit-runner.yml
@@ -24,13 +24,11 @@ on:
         description: Optional JSON object mapping green config key -> secret value.
         required: false
 
-env:
-  NUM_SHARDS: ${{ inputs.num_shards || 1 }}
-
 jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
+      num_shards: ${{ steps.config.outputs.num_shards }}
       shard_indices: ${{ steps.gen.outputs.shard_indices }}
       scenario_path: ${{ steps.scenario.outputs.path }}
       scenario_base: ${{ steps.scenario.outputs.base }}
@@ -69,8 +67,29 @@ jobs:
           echo "path=$scenario" >> "$GITHUB_OUTPUT"
           echo "base=$base" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve shard count
+        id: config
+        shell: bash
+        env:
+          INPUT_NUM_SHARDS: ${{ inputs.num_shards }}
+          SCENARIO_PATH: ${{ steps.scenario.outputs.path }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${INPUT_NUM_SHARDS}" ]]; then
+            num_shards="${INPUT_NUM_SHARDS}"
+          else
+            num_shards="$(jq -r '.components.gateway.config.assessment_config.num_shards // 1' "${SCENARIO_PATH}")"
+          fi
+
+          if ! [[ "${num_shards}" =~ ^[0-9]+$ ]] || [[ "${num_shards}" -lt 1 ]]; then
+            echo "Invalid num_shards: ${num_shards}" >&2
+            exit 1
+          fi
+
+          echo "num_shards=${num_shards}" >> "$GITHUB_OUTPUT"
+
       - id: gen
-        run: echo "shard_indices=$(seq 0 $(( ${{ inputs.num_shards || 1 }} - 1 )) | jq -sc .)" >> "$GITHUB_OUTPUT"
+        run: echo "shard_indices=$(seq 0 $(( ${{ steps.config.outputs.num_shards }} - 1 )) | jq -sc .)" >> "$GITHUB_OUTPUT"
 
   eval:
     needs: setup
@@ -86,6 +105,7 @@ jobs:
       contents: read
 
     env:
+      NUM_SHARDS: ${{ needs.setup.outputs.num_shards }}
       AGENTBEATS_URL: ${{ inputs.backend_url || vars.QUICK_SUBMIT_BACKEND_URL || 'https://agentbeats.dev' }}
       OIDC_AUDIENCE: ${{ vars.QUICK_SUBMIT_OIDC_AUDIENCE || 'agentbeats-quick-submit-production' }}
       GCP_WIF_PROVIDER: ${{ vars.GCP_WIF_PROVIDER || 'projects/352582078246/locations/global/workloadIdentityPools/agentbeats-prod/providers/github' }}
@@ -483,6 +503,7 @@ jobs:
     env:
       AGENTBEATS_URL: ${{ vars.QUICK_SUBMIT_BACKEND_URL || 'https://agentbeats.dev' }}
       OIDC_AUDIENCE: ${{ vars.QUICK_SUBMIT_OIDC_AUDIENCE || 'agentbeats-quick-submit-production' }}
+      NUM_SHARDS: ${{ needs.setup.outputs.num_shards }}
       SCENARIO_PATH: ${{ needs.setup.outputs.scenario_path }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/quick-submit-runner.yml
+++ b/.github/workflows/quick-submit-runner.yml
@@ -12,7 +12,10 @@ on:
         required: false
         type: string
       num_shards:
-        description: Number of parallel shards to run (default 1)
+        description: >-
+          Soft default number of parallel shards. Used only when the submitted
+          scenario does not set assessment_config.num_shards. The submitter's
+          value takes precedence. Clamped to 20.
         required: false
         type: number
       num_instances:
@@ -71,19 +74,30 @@ jobs:
         id: config
         shell: bash
         env:
-          INPUT_NUM_SHARDS: ${{ inputs.num_shards }}
+          INPUT_NUM_SHARDS: ${{ inputs.num_shards || '' }}
           SCENARIO_PATH: ${{ steps.scenario.outputs.path }}
         run: |
           set -euo pipefail
-          if [[ -n "${INPUT_NUM_SHARDS}" ]]; then
+
+          GITHUB_MATRIX_CAP=20
+
+          scenario_num_shards="$(jq -r '.components.gateway.config.assessment_config.num_shards' "${SCENARIO_PATH}")"
+          if [[ "${scenario_num_shards}" != "null" ]]; then
+            num_shards="${scenario_num_shards}"
+          elif [[ -n "${INPUT_NUM_SHARDS}" ]]; then
             num_shards="${INPUT_NUM_SHARDS}"
           else
-            num_shards="$(jq -r '.components.gateway.config.assessment_config.num_shards // 1' "${SCENARIO_PATH}")"
+            num_shards=1
           fi
 
           if ! [[ "${num_shards}" =~ ^[0-9]+$ ]] || [[ "${num_shards}" -lt 1 ]]; then
             echo "Invalid num_shards: ${num_shards}" >&2
             exit 1
+          fi
+
+          if (( num_shards > GITHUB_MATRIX_CAP )); then
+            echo "Clamping num_shards from ${num_shards} to ${GITHUB_MATRIX_CAP} (GitHub matrix cap)" >&2
+            num_shards=${GITHUB_MATRIX_CAP}
           fi
 
           echo "num_shards=${num_shards}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Respect the submitted scenario’s `assessment_config.num_shards` by default instead of forcing shard count from the reusable runner.

Needs https://github.com/RDI-Foundation/agentbeats/pull/184

## Changes

- `quick-submit-runner.yml`
  - resolve `num_shards` from workflow input if explicitly provided
  - otherwise read it from `components.gateway.config.assessment_config.num_shards` in the submitted scenario
  - keep `shard_index` runner-owned
  - use the resolved shard count for matrix generation, scenario patching, and summary aggregation

- `quick-submit.yml`
  - remove hardcoded `num_shards`
  - let the reusable runner derive shard count from the submission
  
## Testing

Passed https://github.com/RDI-Foundation/agentbeats/actions/runs/25741758807/job/75625337703?pr=184